### PR TITLE
Improve difference detection accuracy + Touch-up

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ difference = cv2.subtract(image1, image2)
 
 # color the mask red
 Conv_hsv_Gray = cv2.cvtColor(difference, cv2.COLOR_BGR2GRAY)
-ret, mask = cv2.threshold(Conv_hsv_Gray, 0, 255,cv2.THRESH_BINARY_INV |cv2.THRESH_OTSU)
+_, mask = cv2.threshold(Conv_hsv_Gray, 0, 255, cv2.THRESH_BINARY_INV)
 difference[mask != 255] = [0, 0, 255]
 
 # add the red mask to the images to make the differences obvious

--- a/main.py
+++ b/main.py
@@ -16,23 +16,23 @@ canvas[imask] = img2[imask]
 cv2.imwrite("result.png", canvas)
 """
 
-# load images
+# Load images
 image1 = cv2.imread("D:/Projects/Input/kot.jpg")
 image2 = cv2.imread("D:/Projects/Input/kotblur.jpg")
 
-# compute difference
+# Compute difference
 difference = cv2.subtract(image1, image2)
 
-# color the mask red
+# Color the mask red
 Conv_hsv_Gray = cv2.cvtColor(difference, cv2.COLOR_BGR2GRAY)
 _, mask = cv2.threshold(Conv_hsv_Gray, 0, 255, cv2.THRESH_BINARY_INV)
 difference[mask != 255] = [0, 0, 255]
 
-# add the red mask to the images to make the differences obvious
+# Add the red mask to the images to make the differences obvious
 image1[mask != 255] = [0, 0, 255]
 image2[mask != 255] = [0, 0, 255]
 
-# store images
+# Write down result
 cv2.imwrite('D:/Projects/Output/diffOverImage1.png', image1)
-cv2.imwrite('D:/Projects/Output/diffOverImage2.png', image1)
+cv2.imwrite('D:/Projects/Output/diffOverImage2.png', image2)
 cv2.imwrite('D:/Projects/Output/diff.png', difference)


### PR DESCRIPTION
This PR aims to improve mask generation accuracy by changing the way thresholding is applied

Otsu Thresholding is automatic thresholding best suited for applications that need foreground-background separation. Our application is image comparison, thresholding by any value greater than 0 will result in lowered accuracy due to changes being overlooked (ie. Thresholding with the value 20 will result in pixels changing less than 20 being skipped).

This PR also includes minor touch-up on code comments and a fix to an output bug where the `image1` gets output to `diffOverImage2` instead of `image1`